### PR TITLE
Fix multi-masters/workers CaaSP Cluster dashboard

### DIFF
--- a/grafana-dashboards-caasp-cluster.yaml
+++ b/grafana-dashboards-caasp-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: grafana-dashboards-caasp-cluster
   namespace: monitoring
   labels:
-     grafana_dashboard: "1"
+    grafana_dashboard: "1"
 data:
   caasp-cluster.json: |-
     {
@@ -146,7 +146,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(kube_node_info{node=\"$masters\"}) % sum(kube_node_status_condition{condition=\"Ready\", node=\"$masters\", status=\"true\"})",
+              "expr": "count(kube_node_info{node=~\"$masters\"}) % sum(kube_node_status_condition{condition=\"Ready\", node=~\"$masters\", status=\"true\"})",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -233,7 +233,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(kube_node_info{node!=\"$masters\"}) % sum(kube_node_status_condition{condition=\"Ready\", node!=\"$masters\", status=\"true\"})",
+              "expr": "count(kube_node_info{node!~\"$masters\"}) % sum(kube_node_status_condition{condition=\"Ready\", node!~\"$masters\", status=\"true\"})",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -399,7 +399,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(kube_node_status_allocatable_memory_bytes{node!=\"$masters\"})",
+              "expr": "sum(kube_node_status_allocatable_memory_bytes{node!~\"$masters\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
@@ -560,7 +560,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(kube_node_status_allocatable_cpu_cores{node!=\"$masters\"})",
+              "expr": "sum(kube_node_status_allocatable_cpu_cores{node!~\"$masters\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
@@ -720,7 +720,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(kube_node_status_allocatable_pods{node!=\"$masters\"})",
+              "expr": "sum(kube_node_status_allocatable_pods{node!~\"$masters\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
@@ -883,7 +883,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "count(kube_node_info{node!=\"$masters\"})",
+              "expr": "count(kube_node_info{node!~\"$masters\"})",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -965,7 +965,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{namespace!=\"\"}) / sum(kube_node_status_allocatable_memory_bytes{node!=\"$masters\"}) * 100",
+              "expr": "sum(container_memory_working_set_bytes{namespace!=\"\"}) / sum(kube_node_status_allocatable_memory_bytes{node!~\"$masters\"}) * 100",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -1048,7 +1048,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "(sum(irate(container_cpu_usage_seconds_total{namespace!=\"\"}[5m])) / sum(kube_node_status_allocatable_cpu_cores{node!=\"$masters\"})) * 100",
+              "expr": "(sum(irate(container_cpu_usage_seconds_total{namespace!=\"\"}[5m])) / sum(kube_node_status_allocatable_cpu_cores{node!~\"$masters\"})) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1130,7 +1130,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(kube_pod_info{namespace!=\"\"}) / sum(kube_node_status_allocatable_pods{node!=\"$masters\"}) * 100",
+              "expr": "sum(kube_pod_info{namespace!=\"\"}) / sum(kube_node_status_allocatable_pods{node!~\"$masters\"}) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1190,7 +1190,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(kube_node_status_condition{condition=\"DiskPressure\", node=\"$masters\", status=\"true\"}) by (condition)",
+              "expr": "sum(kube_node_status_condition{condition=\"DiskPressure\", node=~\"$masters\", status=\"true\"}) by (condition)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1198,7 +1198,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "sum(kube_node_status_condition{condition=\"MemoryPressure\", node=\"$masters\", status=\"true\"}) by (condition)",
+              "expr": "sum(kube_node_status_condition{condition=\"MemoryPressure\", node=~\"$masters\", status=\"true\"}) by (condition)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1206,7 +1206,7 @@ data:
               "refId": "B"
             },
             {
-              "expr": "sum(kube_node_status_condition{condition=\"OutOfDisk\", node=\"$masters\", status=\"true\"}) by (condition)",
+              "expr": "sum(kube_node_status_condition{condition=\"OutOfDisk\", node=~\"$masters\", status=\"true\"}) by (condition)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1214,7 +1214,7 @@ data:
               "refId": "C"
             },
             {
-              "expr": "sum(kube_node_status_condition{condition=\"Ready\", node=\"$masters\", status=\"true\"}) by (condition)",
+              "expr": "sum(kube_node_status_condition{condition=\"Ready\", node=~\"$masters\", status=\"true\"}) by (condition)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1303,7 +1303,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(kube_node_status_condition{condition=\"DiskPressure\", node!=\"$masters\", status=\"true\"}) by (condition)",
+              "expr": "sum(kube_node_status_condition{condition=\"DiskPressure\", node!~\"$masters\", status=\"true\"}) by (condition)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1311,7 +1311,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "sum(kube_node_status_condition{condition=\"MemoryPressure\", node!=\"$masters\", status=\"true\"}) by (condition)",
+              "expr": "sum(kube_node_status_condition{condition=\"MemoryPressure\", node!~\"$masters\", status=\"true\"}) by (condition)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1319,7 +1319,7 @@ data:
               "refId": "B"
             },
             {
-              "expr": "sum(kube_node_status_condition{condition=\"OutOfDisk\", node!=\"$masters\", status=\"true\"}) by (condition)",
+              "expr": "sum(kube_node_status_condition{condition=\"OutOfDisk\", node!~\"$masters\", status=\"true\"}) by (condition)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -1327,7 +1327,7 @@ data:
               "refId": "C"
             },
             {
-              "expr": "sum(kube_node_status_condition{condition=\"Ready\", node!=\"$masters\", status=\"true\"}) by (condition)",
+              "expr": "sum(kube_node_status_condition{condition=\"Ready\", node!~\"$masters\", status=\"true\"}) by (condition)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,

--- a/grafana-dashboards-caasp-namespaces.yaml
+++ b/grafana-dashboards-caasp-namespaces.yaml
@@ -5,7 +5,7 @@ metadata:
   name: grafana-dashboards-caasp-namespaces
   namespace: monitoring
   labels:
-     grafana_dashboard: "1"
+    grafana_dashboard: "1"
 data:
   caasp-namespaces.json: |-
     {
@@ -225,7 +225,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(kube_node_status_allocatable_memory_bytes{node!=\"$masters\"})",
+              "expr": "sum(kube_node_status_allocatable_memory_bytes{node!~\"$masters\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
@@ -386,7 +386,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(kube_node_status_allocatable_cpu_cores{node!=\"$masters\"})",
+              "expr": "sum(kube_node_status_allocatable_cpu_cores{node!~\"$masters\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
@@ -546,7 +546,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(kube_node_status_allocatable_pods{node!=\"$masters\"})",
+              "expr": "sum(kube_node_status_allocatable_pods{node!~\"$masters\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
@@ -786,7 +786,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "(sum(irate(container_cpu_usage_seconds_total{namespace!=\"\"}[5m])) / sum(kube_node_status_allocatable_cpu_cores{node!=\"$masters\"})) * 100",
+              "expr": "(sum(irate(container_cpu_usage_seconds_total{namespace!=\"\"}[5m])) / sum(kube_node_status_allocatable_cpu_cores{node!~\"$masters\"})) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -869,7 +869,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\"}) / sum(kube_node_status_allocatable_memory_bytes{node!=\"$masters\"}) * 100",
+              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\"}) / sum(kube_node_status_allocatable_memory_bytes{node!~\"$masters\"}) * 100",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -952,7 +952,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(kube_pod_info{namespace=\"$namespace\"}) / sum(kube_node_status_allocatable_pods{node!=\"$masters\"}) * 100",
+              "expr": "sum(kube_pod_info{namespace=\"$namespace\"}) / sum(kube_node_status_allocatable_pods{node!~\"$masters\"}) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,


### PR DESCRIPTION
Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

Deploy 3 masters + 2 workers environment and reference to [Grafana doc](https://grafana.com/docs/features/datasources/prometheus/#using-variables-in-queries).

CaaSP Cluster
---

- WAS
![image](https://user-images.githubusercontent.com/49380831/63528078-dd1ac080-c534-11e9-9ccd-095e634d6aa0.png)

- IS
![image](https://user-images.githubusercontent.com/49380831/63527797-55cd4d00-c534-11e9-932c-33eb2242f6a8.png)

CaaSP Namespace
---

- WAS
![image](https://user-images.githubusercontent.com/49380831/63528677-efe1c500-c535-11e9-9b13-561ac78e4e18.png)

- IS
![image](https://user-images.githubusercontent.com/49380831/63528815-39321480-c536-11e9-8330-1a4d62dfd82f.png)
