### PR TITLE
Dashboard titles should be SUSE CaaSP Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CaaSP Grafana Monitoring Dashboards
+# SUSE CaaS Platform Grafana Monitoring Dashboards
 Example files for SUSE CaaS Platform Grafana monitoring dashboards.
 
 

--- a/grafana-dashboards-caasp-cluster.yaml
+++ b/grafana-dashboards-caasp-cluster.yaml
@@ -4171,7 +4171,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "CaaSP Cluster",
+      "title": "SUSE CaaS Platform Cluster",
       "uid": "bT-M5vTik",
       "version": 40
     }

--- a/grafana-dashboards-caasp-etcd-cluster.yaml
+++ b/grafana-dashboards-caasp-etcd-cluster.yaml
@@ -1250,6 +1250,6 @@ data:
         ]
       },
       "timezone": "",
-      "title": "CaaSP ETCD Cluster",
+      "title": "SUSE CaaS Platform ETCD Cluster",
       "version": 215
     }

--- a/grafana-dashboards-caasp-namespaces.yaml
+++ b/grafana-dashboards-caasp-namespaces.yaml
@@ -3168,7 +3168,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "CaaSP Namespaces",
+      "title": "SUSE CaaS Platform Namespaces",
       "uid": "PUTdZMTmz",
       "version": 53
     }

--- a/grafana-dashboards-caasp-nodes.yaml
+++ b/grafana-dashboards-caasp-nodes.yaml
@@ -2513,7 +2513,7 @@ data:
         ]
       },
       "timezone": "utc",
-      "title": "CaaSP Nodes",
+      "title": "SUSE CaaS Platform Nodes",
       "uid": "-xgwW_2mw",
       "version": 32
     }

--- a/grafana-dashboards-caasp-pods.yaml
+++ b/grafana-dashboards-caasp-pods.yaml
@@ -2170,7 +2170,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "CaaSP Pods",
+      "title": "SUSE CaaS Platform Pods",
       "uid": "MfaxMMomz",
       "version": 94
     }


### PR DESCRIPTION
Bug 1161110 - Grafana dashboard should not name "CaaSP" but "SUSE (r) CaaS Platform" 
